### PR TITLE
feat: add daily session history

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Session {
+  type: 'working' | 'break'
+  duration: number
+  timestamp: number
+}
+
+const RESET_HOUR = 5
+
+export default function HistoryPage() {
+  const [history, setHistory] = useState<Session[]>([])
+
+  useEffect(() => {
+    const saved = localStorage.getItem('pomodoroData')
+    if (!saved) return
+    try {
+      const data = JSON.parse(saved)
+      const sessions: Session[] = data.history || []
+
+      const now = new Date()
+      const boundary = new Date()
+      boundary.setHours(RESET_HOUR, 0, 0, 0)
+      if (now.getHours() < RESET_HOUR) {
+        boundary.setDate(boundary.getDate() - 1)
+      }
+
+      setHistory(sessions.filter((s) => s.timestamp >= boundary.getTime()))
+    } catch {
+      // ignore parse errors
+    }
+  }, [])
+
+  const format = (sec: number) => {
+    const hrs = Math.floor(sec / 3600)
+    const mins = Math.floor((sec % 3600) / 60)
+    const secs = sec % 60
+    return `${hrs > 0 ? `${hrs}:` : ''}${mins
+      .toString()
+      .padStart(hrs > 0 ? 2 : 1, '0')}:${secs.toString().padStart(2, '0')}`
+  }
+
+  return (
+    <main className="min-h-screen p-4 flex flex-col items-center">
+      <h1 className="text-2xl font-bold mb-6">Today's History</h1>
+      {history.length === 0 ? (
+        <p className="text-neutral-500">No sessions yet.</p>
+      ) : (
+        <ul className="w-full max-w-md space-y-4">
+          {history.map((session, idx) => (
+            <li
+              key={idx}
+              className="flex justify-between border-b pb-2 text-lg"
+            >
+              <span className="capitalize">{session.type}</span>
+              <span>{format(session.duration)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,8 +9,11 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <main className="min-h-screen flex items-center justify-center p-4">
+    <main className="min-h-screen flex flex-col items-center justify-center p-4">
       <PomodoroTimer />
+      <a href="/history" className="mt-8 text-blue-600 hover:underline">
+        View today\'s history
+      </a>
     </main>
   );
 }

--- a/components/pomodoro-timer.tsx
+++ b/components/pomodoro-timer.tsx
@@ -9,11 +9,18 @@ import { useEffect, useRef, useState } from "react";
 
 type TimerState = "idle" | "working" | "break";
 
+interface SessionEntry {
+  type: TimerState;
+  duration: number;
+  timestamp: number;
+}
+
 interface TimerData {
   breakTime: number;
   totalWorkToday: number;
   bonusCount: number;
   lastTimestamp: number;
+  history: SessionEntry[];
 }
 
 const WORK_TO_BREAK_RATIO = 0.25; // 25% passive break
@@ -27,6 +34,7 @@ export default function PomodoroTimer() {
   const [elapsedTime, setElapsedTime] = useState(0);
   const [totalWorkToday, setTotalWorkToday] = useState(0);
   const [bonusCount, setBonusCount] = useState(0);
+  const [history, setHistory] = useState<SessionEntry[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
   const [audioLoaded, setAudioLoaded] = useState(false);
 
@@ -38,6 +46,13 @@ export default function PomodoroTimer() {
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   useWakeLock();
+
+  const recordSession = (duration: number, type: TimerState) => {
+    setHistory((h) => [
+      ...h,
+      { type, duration, timestamp: Date.now() },
+    ])
+  }
 
   // Initialize audio with better error handling
   useEffect(() => {
@@ -121,11 +136,13 @@ export default function PomodoroTimer() {
           setTotalWorkToday(0);
           setBreakTime(0);
           setBonusCount(0);
+          setHistory([]);
         } else {
           // Same period: restore previous values
           setTotalWorkToday(data.totalWorkToday);
           setBreakTime(data.breakTime);
           setBonusCount(data.bonusCount);
+          setHistory(data.history || []);
         }
       }
       setIsInitialized(true);
@@ -144,12 +161,13 @@ export default function PomodoroTimer() {
         totalWorkToday,
         bonusCount,
         lastTimestamp: Date.now(),
+        history,
       };
       localStorage.setItem("pomodoroData", JSON.stringify(data));
     };
 
     saveData();
-  }, [breakTime, totalWorkToday, bonusCount, isInitialized]);
+  }, [breakTime, totalWorkToday, bonusCount, history, isInitialized]);
 
   // Timer logic
   useEffect(() => {
@@ -175,6 +193,7 @@ export default function PomodoroTimer() {
         if (timerState === "break") {
           // Check if break time is over
           if (elapsed >= breakTime) {
+            recordSession(breakTime, "break");
             setTimerState("idle");
             setBreakTime(0);
 
@@ -264,9 +283,11 @@ export default function PomodoroTimer() {
       }
       setBonusCount(newCount);
       setTotalWorkToday(newTotal);
+      recordSession(elapsedTime, "working");
     } else if (timerState === "break") {
       // Subtract used break time from total break time
       setBreakTime((prev) => Math.max(0, prev - elapsedTime));
+      recordSession(elapsedTime, "break");
     }
 
     setTimerState("idle");


### PR DESCRIPTION
## Summary
- record session history in `pomodoroData`
- show link to new history page
- add `/history` page that lists work/break sessions for the day

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b634b7648328a677ce6a595abdc7